### PR TITLE
Explicitly call close() on container.ContextWriter

### DIFF
--- a/container.go
+++ b/container.go
@@ -816,6 +816,9 @@ func (container *Container) CreateDockerContext() error {
 	// Always include the sas-install role since its used by other roles
 	container.AddDirectoryToContext("util/static-roles-"+container.SoftwareOrder.DeploymentType+"/sas-install/", "roles/sas-install/", "sas-install")
 
+	// Close tar file
+	container.ContextWriter.Close()
+
 	return nil
 }
 


### PR DESCRIPTION
Currently the build_context.tar files generated by container.go are faulty. Untarring returns an error saying "tar: Unexpected EOF in archive". Adding a call to close() to explicitly close the tar file after all content has been added.